### PR TITLE
Refactor Nix release expression

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -15,7 +15,7 @@ let
 
   jobs = rec {
     linux_amd64 = with pkgs_linux; stdenv.mkDerivation {
-      name = "rainbow-lollipop-tarball";
+      name = "rainbow-lollipop-linux";
       version = "0.0.1";
       src = ./.;
 

--- a/release.nix
+++ b/release.nix
@@ -33,8 +33,10 @@ let
   };
 
   withSystem = system: let
-    pkgs = import <nixpkgs> (getSysAttrs system);
-  in rainbowLollipop pkgs;
+    sysAttrs = getSysAttrs system;
+    pkgs = import <nixpkgs> sysAttrs;
+    result = rainbowLollipop pkgs;
+  in if sysAttrs ? crossSystem then result.crossDrv else result;
 
 in {
   build = genAttrs supportedSystems withSystem;

--- a/release.nix
+++ b/release.nix
@@ -8,8 +8,9 @@ let
 
     buildInputs = [
       cmake vala_0_26 zeromq2 pkgconfig glib gtk3 clutter_gtk webkitgtk
-      gnome3.libgee sqlite udev xorg.libpthreadstubs xorg.libXdmcp
-      xorg.libxshmfence libxkbcommon
+      gnome3.libgee sqlite
+    ] ++ optionals (!(stdenv ? cross)) [
+      udev xorg.libpthreadstubs xorg.libXdmcp xorg.libxshmfence libxkbcommon
     ];
   };
 

--- a/release.nix
+++ b/release.nix
@@ -15,10 +15,10 @@ let
   };
 
   supportedSystems = [
-    "i686-linux" "x86_64-linux" "i686-w64-mingw" "x86_64-w64-mingw"
+    "i686-linux" "x86_64-linux" "i686-w64-mingw32" "x86_64-w64-mingw32"
   ];
 
-  getSysAttrs = system: if hasSuffix "-w64-mingw" system then {
+  getSysAttrs = system: if hasSuffix "-w64-mingw32" system then {
     crossSystem = let
       is64 = hasPrefix "x86_64" system;
     in {

--- a/release.nix
+++ b/release.nix
@@ -1,38 +1,40 @@
-let 
-    pkgs_linux = import <nixpkgs> {};
-    pkgs_windows = import <nixpkgs> {
-        crossSystem = {
-            config = "x86_64-w64-mingw32";
-            arch = "x86_64";
-            libc = "msvcrt";
-            platform = {};
-            openssl.system = "mingw64";
-        };
+let
+  pkgs_linux = import <nixpkgs> {};
 
+  pkgs_windows = import <nixpkgs> {
+    crossSystem = {
+      config = "x86_64-w64-mingw32";
+      arch = "x86_64";
+      libc = "msvcrt";
+      platform = {};
+      openssl.system = "mingw64";
     };
-    system = "x86_64-linux";
-    jobs = rec {
-        linux_amd64 = 
-            with pkgs_linux;
-            stdenv.mkDerivation {
-                name = "rainbow-lollipop-tarball";
-                version = "0.0.1";
-                src = ./.;
-                
-                buildInputs = [cmake vala_0_26 zeromq2 pkgconfig glib gtk3 clutter_gtk webkitgtk
-                               gnome3.libgee sqlite udev xorg.libpthreadstubs xorg.libXdmcp
-                               xorg.libxshmfence libxkbcommon];
-            };
-        windows_64bit =
-            with pkgs_windows;
-            (stdenv.mkDerivation {
-                name = "rainbow-lollipop-windows";
-                version = "0.0.1";
-                src = ./.;
-                
-                buildInputs = [cmake vala_0_26 zeromq2 pkgconfig glib gtk3 clutter_gtk webkitgtk
-                               gnome3.libgee sqlite udev xorg.libpthreadstubs xorg.libXdmcp
-                               xorg.libxshmfence libxkbcommon];
-            }).crossDrv;
+  };
+
+  system = "x86_64-linux";
+
+  jobs = rec {
+    linux_amd64 = with pkgs_linux; stdenv.mkDerivation {
+      name = "rainbow-lollipop-tarball";
+      version = "0.0.1";
+      src = ./.;
+
+      buildInputs = [
+        cmake vala_0_26 zeromq2 pkgconfig glib gtk3 clutter_gtk webkitgtk
+        gnome3.libgee sqlite udev xorg.libpthreadstubs xorg.libXdmcp
+        xorg.libxshmfence libxkbcommon
+      ];
     };
+    windows_64bit = with pkgs_windows; (stdenv.mkDerivation {
+      name = "rainbow-lollipop-windows";
+      version = "0.0.1";
+      src = ./.;
+
+      buildInputs = [
+        cmake vala_0_26 zeromq2 pkgconfig glib gtk3 clutter_gtk webkitgtk
+        gnome3.libgee sqlite udev xorg.libpthreadstubs xorg.libXdmcp
+        xorg.libxshmfence libxkbcommon
+      ];
+    }).crossDrv;
+  };
 in jobs


### PR DESCRIPTION
Abstracts away most of the repetitive cruft and generates system attributes for `supportedSystems`. We also now use `x86_64-w64-mingw` instead of `x86_64-w64-mingw32`, which sounded a bit misleading (if that
doesn't work, we should fix this in [\<nixpkgs\>](https://github.com/NixOS/nixpkgs), not here).

Everything is now based on single derivation attributes, so we can use `crossAttrs` accordingly to separate cross building stuff from the main derivation without duplication. It also makes the base derivation much more readable.