### PR TITLE
spellcheck: Fix various spelling/grammar mistakes in the comments.

### DIFF
--- a/src/alaia.vala
+++ b/src/alaia.vala
@@ -44,13 +44,13 @@ namespace RainbowLollipop {
 
     /**
      * Extended Version of WebKit's WebView which is able to store
-     * A reference to a HistoryTrack along with it and offers methods
-     * To communicate with the web-extension-process of this view.
+     * a reference to a HistoryTrack along with it and offers methods
+     * to communicate with the web-extension-process of this view.
      */
     public class TrackWebView : WebKit.WebView {
         /**
          * Stores a reference to the HistoryTrack that is associated with
-         * This WebView
+         * this WebView
          */
         public HistoryTrack track{ get;set; }
         private SearchWidget search;
@@ -65,8 +65,8 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Asks The web-extension-process wheter this webview currently
-         * Needs input from the keyboard e.g. to fill content into a
+         * Asks The web-extension-process whether this webview currently
+         * needs input from the keyboard e.g. to fill content into a
          * HTML form-element.
          */
         public async void needs_direct_input(IPCCallback cb, Gdk.EventKey e) {
@@ -341,7 +341,7 @@ namespace RainbowLollipop {
                 register_session : true
             );
 
-            //Internationalization
+            // Internationalization
             init_locale();
 
             // Load config
@@ -437,7 +437,7 @@ namespace RainbowLollipop {
 
         /**
          * Obtain The WebView that is associated to the given HistoryTrack
-         * If no WebView Exists yet, it shall be created and added to the
+         * If no WebView exists yet, it shall be created and added to the
          * Applications WebView-List
          */
         public TrackWebView get_web_view(HistoryTrack t) {
@@ -462,7 +462,7 @@ namespace RainbowLollipop {
 
         /**
          * Destroys the WebView associated with the given HistoryTrack
-         * Does nothing if there is no associated WebView
+         * does nothing if there is no associated WebView
          */
         public void destroy_web_view(HistoryTrack t) {
             if (this.webviews.has_key(t))
@@ -471,8 +471,8 @@ namespace RainbowLollipop {
     
         /**
          * Puts the WebView that corresponds to the given HistoryTrack
-         * Into the foreground, thereby moving the currently displayed WebView
-         * To the background.
+         * into the foreground, thereby moving the currently displayed WebView
+         * to the background.
          */
         public void show_web_view(HistoryTrack t) {
             if (this.webviews.has_key(t)){
@@ -484,8 +484,8 @@ namespace RainbowLollipop {
 
         /**
          * Checks whether there lies a sessionfile in the cache which can be used
-         * To reconstruct a browsing session. This should happen when you start the
-         * Program.
+         * to reconstruct a browsing session. This should happen when you start the
+         * program.
          */
         public bool old_session_available() {
             return FileUtils.test(GLib.Environment.get_user_cache_dir()+Config.C+SESSION_FILE,
@@ -494,8 +494,8 @@ namespace RainbowLollipop {
 
         /**
          * Restores a session from a JSON-file. Performs basic validity checks on the
-         * Sessionfile. See Also: The [Class].from_json(JsonNode n)-Constructors
-         * Of several Classes around the Project
+         * sessionfile. See Also: The [Class].from_json(JsonNode n)-Constructors
+         * of several Classes around the Project
          */
         public void restore_session() {
             this.state = TracklistState.S();
@@ -552,10 +552,10 @@ namespace RainbowLollipop {
         }
 
         /**
-         * First Callback an occuring key-event will pass through
+         * First Callback an occurring key-event will pass through
          * This method will determine, wheter it is necessary to obtain any further
-         * Information from web-extension-procecsses.
-         * Further it will determine wheter the occured event is relevant for the
+         * information from web-extension-procecsses.
+         * Further it will determine wheter the occurred event is relevant for the
          * current application state and drop it, if not so.
          *
          * If there is no necessity to obtain further information from the
@@ -606,7 +606,7 @@ namespace RainbowLollipop {
          * This method executes actions according to an incoming preprocessed
          * Gdk.EventKey e (See preprocess_key_press_event(Gdk.EventKey e) for furhter info)
          * The action that will be taken is depending on which state the application
-         * Is currently in.
+         * is currently in.
          */
         public void do_key_press_event(Gdk.EventKey e) {
             if (this.state is NormalState) {

--- a/src/alaia_extension.vala
+++ b/src/alaia_extension.vala
@@ -25,7 +25,7 @@ using Gee;
  * This Worker receives IPC-Calls from the main-thread, processes them and
  * returns appropriate answers.
  * The Worker only anwers if the page id of this webextension is the same as
- * the page id that the IPC-Call was issued for. Otherwise it will drop the request
+ * the page id that the IPC-Call was issued for. Otherwise it will drop the request.
  */
 public class ZMQWorker {
     private static const string VENT = "tcp://127.0.0.1:26010";
@@ -37,7 +37,7 @@ public class ZMQWorker {
     private static ZMQ.Socket sender;
 
     /**
-     * Initialize by storing a reference to the AlaiaExtension that this Worder handles
+     * Initialize by storing a reference to the AlaiaExtension that this Worker handles
      */
     public static void init(AlaiaExtension e) {
         ZMQWorker.aext = e;

--- a/src/application_states.vala
+++ b/src/application_states.vala
@@ -22,10 +22,10 @@
 namespace RainbowLollipop {
     /**
      * This Interface must be implemented by every class that
-     * represents an application state
+     * represents an application state.
      * Application states are mutually exclusive, so only
-     * one application state can be active at a time
-     * Application states are singleton classes
+     * one application state can be active at a time.
+     * Application states are singleton classes.
      */
     interface IApplicationState : GLib.Object {
         public abstract void enter();

--- a/src/config.vala
+++ b/src/config.vala
@@ -76,8 +76,8 @@ namespace RainbowLollipop {
          */
         public uint8 track_height {get; set; default = 0x80;}
         /**
-         * Distance between a tracks top border and it's topmost node and
-         * distance between a tracks bottom border and it's bottommost node
+         * Distance between a track's top border and its topmost node and
+         * distance between a track's bottom border and its bottommost node
          * in pixels
          */
         public uint8 track_spacing {get; set; default = 0x10;}
@@ -91,7 +91,7 @@ namespace RainbowLollipop {
          */
         public uint8 node_height {get; set; default = 0x40;}
         /**
-         * Space between two neighbouring nodes in pixels
+         * Space between two adjacent nodes in pixels
          */
         public uint8 node_spacing {get; set; default = 0x10;}
         /**

--- a/src/download_node.vala
+++ b/src/download_node.vala
@@ -81,7 +81,7 @@ namespace RainbowLollipop {
     }
 
     /**
-     * A special kind of Node wich represents a download and shows its progress
+     * A special kind of Node which represents a download and shows its progress
      */
     class DownloadNode : Node {
         private WebKit.Download dl;

--- a/src/empty_track.vala
+++ b/src/empty_track.vala
@@ -184,7 +184,7 @@ namespace RainbowLollipop {
     }
 
     /**
-     * Represents an autocompletion hint for EmtpyTrack
+     * Represents an autocompletion hint for EmptyTrack
      */
     class AutoCompletionHint : Clutter.Actor {
         protected string heading = "";
@@ -257,7 +257,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Common logic that occurs everytime when a user decides to use a
+         * Common logic that occurs every time when a user decides to use a
          * Completion hint. e.g. set the application state to normal browsing mode
          */
         public void trigger_execute(Clutter.Actor a){

--- a/src/error_node.vala
+++ b/src/error_node.vala
@@ -22,7 +22,7 @@
 namespace RainbowLollipop {
     /**
      * This is a bullet that resembles a stopsign and renders
-     * Its parent stored errorcode as text.
+     * its parent stored errorcode as text.
      */
     class ErrorBullet : Clutter.Actor {
         private Clutter.Canvas c;

--- a/src/history.vala
+++ b/src/history.vala
@@ -21,11 +21,11 @@
 
 namespace RainbowLollipop {
     /**
-     * A History class that logs calls to URLs into a SQL Database
+     * A History class that logs calls to URLs into a SQL Database.
      * It serves as HintProvider and can deliver hints to URLS that have
-     * Already been surfed to.
+     * already been surfed to.
      * TODO: There should be a third column which is called HIS_TITLE
-     *       An URL should also qualify for being a hint when it's associated HTML-title
+     *       An URL should also qualify for being a hint when its associated HTML-title
      *       contains the searched string fragment.
      *       Fuzzy searching would also be awesome.
      */
@@ -89,7 +89,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Logs a callto an URL into the History Database
+         * Logs a call to an URL into the History Database
          */
         public void log_call(string url) {
             // Check if entry already exists in db

--- a/src/history_track.vala
+++ b/src/history_track.vala
@@ -53,7 +53,7 @@ namespace RainbowLollipop {
 
         /**
          * The node that represents the website which is currently being displayed
-         * In this HistoryTrack's WebView.
+         * in this HistoryTrack's WebView.
          * If this property is set, it automatically causes the webview to load
          * the site of the new node.
          */
@@ -321,7 +321,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Callback that is called when there is a faviconavailable for the current node
+         * Callback that is called when there is a favicon available for the current node
          * TODO: check if it is possible to bind this directly to the concerned node.
          *       relaying it here may cause the false node to be assigned a wrong icon
          */
@@ -362,7 +362,7 @@ namespace RainbowLollipop {
 
         /**
          * Causes HistoryTrack and Browser to go to the previous node and load
-         * it's associated website.
+         * its associated website.
          */
         public void go_back() {
             Node? prv = this.current_node.get_previous();
@@ -423,7 +423,7 @@ namespace RainbowLollipop {
         /**
          * This method gets called when the current website finishes loading
          * a resource.
-         * If and error occurs, it  will remove the node that represents the
+         * If an error occurs, it  will remove the node that represents the
          * website and replace it with an errornode.
          * TODO: Same as in log_download()
          */
@@ -447,7 +447,7 @@ namespace RainbowLollipop {
 
         /**
          * Stops the current node indicating that it is loading and sets
-         * it's favicon, if there is any.
+         * its favicon, if there is any.
          */
         public void finish_call(Cairo.Surface? favicon) {
             if(this._current_node is SiteNode) {
@@ -469,7 +469,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * This method shall be called everytime this track
+         * This method shall be called every time this track
          * is selected as the current track.
          */
         public new void prepare() {
@@ -479,9 +479,9 @@ namespace RainbowLollipop {
         }
 
         /**
-         * This method shall be called everytime this track
+         * This method shall be called every time this track
          * ceases to be the current_track of the Tracklist
-         * and performs cleanup operations
+         * and performs cleanup operations.
          */
         public new void cleanup() {
             base.cleanup();

--- a/src/ipc.vala
+++ b/src/ipc.vala
@@ -22,9 +22,9 @@
 namespace RainbowLollipop {
     /**
      * Used to wrap all the data that is necessary to call a callback to a
-     * successfully completed IPC call including the callback itself
+     * successfully completed IPC call including the callback itself.
      * It is intended to be a universally applicable class but currently
-     * it is only able to cover the needs_direct_input-usecase
+     * it is only able to cover the needs_direct_input-usecase.
      * TODO: Modify this wrapper and the code in general to be able
      *       To store arbitrary callback / parameter combinations
      */
@@ -65,16 +65,16 @@ namespace RainbowLollipop {
     }
 
     /**
-     * A callback that is called when an IPC call has finished sucessfully
+     * A callback that is called when an IPC call has finished successfully
      */
     public delegate void IPCCallback(Gdk.EventKey e);
 
     /**
-     * The ZMQVent distributes ipc calls to each available WebExtension
+     * The ZMQVent distributes ipc calls to each available WebExtension.
      * It is a Vent in the sense of the libzmq workload distributor design
      * pattern with a little exception. Along with each call goes the id
-     * Of a specific WebExtension and only this one Webextension will answer to
-     * The call.
+     * of a specific WebExtension and only this one Webextension will answer to
+     * the call.
      *
      * TODO: Introduce reasonable timeouts to the calls.
      */
@@ -96,7 +96,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Sends a request to a WebView if this webview directly needs te input
+         * Sends a request to a WebView if this webview directly needs the input
          * from the Keyboard
          */
         public static async void needs_direct_input(TrackWebView w,IPCCallback cb, Gdk.EventKey e) {
@@ -142,8 +142,8 @@ namespace RainbowLollipop {
         private static ZMQ.Socket receiver;
 
         /**
-         * Register a callback that is being mapped to a call id
-         * When a answer to the call with the given call id arrives, the callback will
+         * Register a callback that is being mapped to a call id.
+         * When an answer to the call with the given call id arrives, the callback will
          * be executed
          */
         public static void register_callback(uint32 callid, IPCCallbackWrapper cbw) {

--- a/src/nodes.vala
+++ b/src/nodes.vala
@@ -43,7 +43,7 @@ namespace RainbowLollipop {
 
     /**
      * A Constraint that keeps an area aligned to
-     * The source's right border and the target's left border.
+     * the source's right border and the target's left border.
      * Used to assign an area to NodeConnectors
      */
     public class ConnectorConstraint : Clutter.Constraint {
@@ -77,7 +77,7 @@ namespace RainbowLollipop {
     }
 
     /**
-     * An Actor that draws a connecting line between two nodes
+     * An Actor that draws a connecting line between two nodes.
      * You can configure the connectors thickness with the config-entry 'connector_stroke'
      */
     public class Connector : Clutter.Actor {
@@ -217,7 +217,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Takes this node an all it's childnodes, creates a new track, removes said
+         * Takes this node an all its childnodes, creates a new track, removes said
          * nodes from their current track and assigns them to the newly created track
          */
         public void move_to_new_track() {
@@ -295,9 +295,9 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Takes care of recursively deleting this node and all child nodes
+         * Takes care of recursively deleting this node and all child nodes.
          * Causes this Node's track to recalculate its height and rerender
-         * the node-tree
+         * the node-tree.
          */
         public void delete_node(bool rec_initial=true) {
             bool need_new_current_node = false;
@@ -346,7 +346,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Lets each childnode of this node recalculate it's y-coordinate positions
+         * Lets each childnode of this node recalculate its y-coordinate positions
          */
         public void recalculate_nodes() {
             foreach (Node n in this.childnodes) {
@@ -396,7 +396,7 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Ensures that this Node and its Connector have colors according to its Track
+         * Ensures that this Node and its Connector have colors according to their Track
          */
         protected void adapt_to_track() {
             if (this.previous != null) {

--- a/src/session_select.vala
+++ b/src/session_select.vala
@@ -21,7 +21,7 @@
 
 namespace RainbowLollipop {
     /**
-     * Implements a dialog that let's the user choose whether he wants
+     * Implements a dialog that lets the user choose whether he wants
      * to restore the saved browsing session or rather start a new one
      */
     class RestoreSessionDialog : Clutter.Actor {

--- a/src/site_node.vala
+++ b/src/site_node.vala
@@ -212,7 +212,7 @@ namespace RainbowLollipop {
     /**
      * A tooltip that can be attached to an actor
      * TODO: Maybe could be made cooler by attaching to
-     *       The Actor's mouse-over events instead of manually coding it there
+     *       the Actor's mouse-over events instead of manually coding it there
      */
     public class Tooltip : Clutter.Actor {
         private const uint8 OPACITY = 0xAF;
@@ -429,9 +429,9 @@ namespace RainbowLollipop {
 
         /**
          * Adapts this nodes appearance to the HistoryTrack that it currently resides
-         * in. All subcomponents of this Node then have a color that matches the Track
+         * in. All subcomponents of this Node then have a color that matches the Track.
          * This is for example needed when a Branch of nodes is moved to a new Track
-         * By the create-new-track-from-branch-feature.
+         * by the create-new-track-from-branch-feature.
          */
         public new void adapt_to_track() {
             base.adapt_to_track();

--- a/src/track.vala
+++ b/src/track.vala
@@ -121,14 +121,14 @@ namespace RainbowLollipop {
         }
 
         /**
-         * This method shall be called everytime this track
+         * This method shall be called every time this track
          * is selected as the current track.
          */
         public void prepare() {
         }
 
         /**
-         * This method shall be called everytime this track
+         * This method shall be called every time this track
          * ceases to be the current_track of the Tracklist
          * and performs cleanup operations
          */

--- a/src/tracklist.vala
+++ b/src/tracklist.vala
@@ -79,15 +79,15 @@ namespace RainbowLollipop {
     }
 
     /**
-     * Represents a list of the currently opened HistoryTracks
+     * Represents a list of the currently opened HistoryTracks.
      * The Tracklist also contains a special Track which is called
-     * the EmptyTrack. The Empty Track offers users the possibility
-     * To open new Websites
+     * the EmptyTrack. The EmptyTrack offers users the possibility
+     * to open new Websites
      */
     public class TrackList : Clutter.Actor {
         /**
          * Holds a reference to the currently active HistoryTrack
-         * of this TrackList
+         * of this TrackList.
          * The current_track is always the HistoryTrack that's associated
          * WebView is currently displayed in the foreground
          */
@@ -184,7 +184,7 @@ namespace RainbowLollipop {
 
         /**
          * Generate a new Track from the given node and add it to
-         *  this Tracklist
+         * this Tracklist.
          */
         public void add_track_with_node(Node n, SiteNode? current_node, string search_string="") {
             var t = new HistoryTrack.with_node(this, (n as SiteNode), current_node, search_string);
@@ -192,8 +192,8 @@ namespace RainbowLollipop {
         }
 
         /**
-         * Returns the Track that the given Node belongs to
-         * Returns null if no Track belongs to the given Node
+         * Returns the Track that the given Node belongs to.
+         * Returns null if no Track belongs to the given Node.
          */
         public Track? get_track_of_node(Node n){
             foreach (Clutter.Actor t in this.get_children()) {


### PR DESCRIPTION
While digging into the source base I stumbled upon various spelling and
grammar mistakes. -> fix them, no code changes.

Mainly it's <-> its :)

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>