### PR TITLE
fix builderror due to missing underscore in config_dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ else()
         "src/search_widget.vala"
         "src/error_node.vala"
         "src/application_states.vala"
-        "src/configdialog.vala"
+        "src/config_dialog.vala"
     PACKAGES
         gtk+-3.0
         clutter-1.0


### PR DESCRIPTION
When building the current version it does not compile due to this error
[ 20%] Built target mofiles
make[2]: *** Keine Regel vorhanden, um das Ziel „src/configdialog.vala“,
benötigt von „src/dummy.vala_valac.stamp“, zu erstellen.  Schluss.
CMakeFiles/Makefile2:212: die Regel für Ziel
„CMakeFiles/rainbow-lollipop.dir/all“ scheiterte

-> simple copy paste error

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>