### PR TITLE
Fix the Nix Package

### DIFF
--- a/libhttpseverywhere_no_rulesets_target.patch
+++ b/libhttpseverywhere_no_rulesets_target.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 44d162a..10b1e58 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,16 +92,6 @@ add_definitions(-w)
+ 
+ add_library("httpseverywhere" SHARED ${VALA_LIB_C})  
+ 
+-add_custom_target(rulesets ALL
+-    COMMAND
+-        git submodule init
+-    COMMAND
+-        git submodule update
+-    COMMENT
+-        "Fetching Rulesets"
+-)    
+-        
+-
+ add_custom_target(typelib ALL
+     COMMAND
+         g-ir-compiler --shared-library=libhttpseverywhere.so HTTPSEverywhere-${VERSION}.gir

--- a/release.nix
+++ b/release.nix
@@ -1,14 +1,31 @@
 with import <nixpkgs/lib>;
 
 let
+  libhttpseverywhere = pkgs: with pkgs; stdenv.mkDerivation rec {
+    name = "libhttpseverywhere-${version}";
+    version = "0.0.2";
+    src = fetchgit {
+        url = "https://github.com/grindhold/libhttpseverywhere/";
+        sha256 = "0hp9szklp8g5bkcm47vbkhspwjdm5x4ghhgwp9yd201s2qkl0hsq";
+        rev = "5827c6bca6891a136e4f93768f642f57b5d1cbd9"; # Version 0.0.2
+        fetchSubmodules = true;
+    };
+    patches = [ ./libhttpseverywhere_no_rulesets_target.patch ];
+    dontUseCmakeBuildDir = true;
+    buildInputs = [
+      cmake vala_0_28 pkgconfig glib gtk3 gnome3.libgee libxml2 git
+    ];
+  };
+
   rainbowLollipop = pkgs: with pkgs; stdenv.mkDerivation rec {
     name = "rainbow-lollipop-${version}";
     version = "0.0.1";
     src = ./.;
 
+    dontUseCmakeBuildDir = true;
     buildInputs = [
-      cmake vala_0_26 zeromq pkgconfig glib gtk3 clutter_gtk webkitgtk
-      gnome3.libgee sqlite gettext
+      cmake vala_0_28 zeromq pkgconfig glib gtk3 clutter_gtk webkitgtk
+      gnome3.libgee sqlite gettext epoxy (libhttpseverywhere pkgs)
     ] ++ optionals (!(stdenv ? cross)) [
       udev xorg.libpthreadstubs xorg.libXdmcp xorg.libxshmfence libxkbcommon
     ];


### PR DESCRIPTION
The build doesn’t fail, but there seem to be some runtime dependencies missing:

```
TLS/SSL support not available; install glib-networking
```

I hope this is a useful beginning.